### PR TITLE
Fix import error to tslib caused by being a es2015 module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "noImplicitAny": false,
-        "module": "es2015",
+        "module": "commonjs",
         "target": "es5",
         "moduleResolution": "node",
         "emitDecoratorMetadata": true,


### PR DESCRIPTION
This resolves the error mentioned in #15 by @ErikGrijzen and @YvesCandel. The problem is (shown in the stacktrace when running on android instead of ios) that the runtime seems to have problems with import * as tslib from 'tslib'. Though it works with require('tslib'), so building as commonjs module seems to be suitable. 