### PR TITLE
Disabled importHelpers that cause the app to crash on android

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
         "declaration": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
-        "importHelpers": true,
+        "importHelpers": false,
         "types": [],
         "lib": [
             "dom",


### PR DESCRIPTION
To get the change working with android we have to disable importHelpers, though I cannot explain you why:

See https://github.com/NativeScript/NativeScript/issues/3846